### PR TITLE
fix(#9): adds support for CouchDb v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,15 @@ jobs:
       - run: npm run test
 
   integration:
+    strategy:
+      fail-fast: false
+      matrix:
+        couchdb-image: [ 'public.ecr.aws/medic/cht-couchdb:4.3.0', '3.3.3' ]
+
     name: Integration
     runs-on: ubuntu-22.04
+    env:
+      COUCHDB_IMAGE: ${{ matrix.couchdb-image }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 20.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        couchdb-image: [ 'public.ecr.aws/medic/cht-couchdb:4.3.0', '3.3.3' ]
+        couchdb-image: [ 'public.ecr.aws/medic/cht-couchdb:4.3.0', 'couchdb:3.3.3' ]
 
     name: Integration
     runs-on: ubuntu-22.04
@@ -43,6 +43,8 @@ jobs:
 
     name: Smoke test for older node versions
     runs-on: ubuntu-22.04
+    env:
+      COUCHDB_IMAGE: 'couchdb:3.3.3'
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pouchdb-session-authentication",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pouchdb-session-authentication",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "pouchdb-fetch": "^8.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pouchdb-session-authentication",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Plugin that forces session authentication for PouchDb http adapter",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,9 @@ const authenticate = async (db) => {
   const headers = new Headers();
   headers.set('Content-Type', 'application/json');
   headers.set('Accept', 'application/json');
+  const authString = `${db.credentials.username}:${db.credentials.password}`;
+  const token = Buffer.from(decodeURIComponent(encodeURIComponent(authString))).toString('base64');
+  headers.set('Authorization', `Basic ${token}`);
 
   const body = JSON.stringify({ name: db.credentials.username, password: db.credentials.password});
   const response = await db.originalFetch(url.toString(), { method: 'POST', headers, body });

--- a/test/integration/credentials-auth.spec.js
+++ b/test/integration/credentials-auth.spec.js
@@ -91,8 +91,6 @@ describe(`integration with ${authType}`, async function () {
 
     const logs = await collectLogs(100);
 
-    console.log(logs);
-
     expect(utils.getDbRequest(auth.username, logs, tempDbName, '/_all_docs').length).to.equal(1);
     expect(utils.getSessionRequests(logs).length).to.equal(1);
     expect(utils.getCookieAuthRequests(auth.username, logs).length).to.equal(1);
@@ -110,8 +108,6 @@ describe(`integration with ${authType}`, async function () {
     await utils.createAdmin(auth.username, 'password change');
     await expect(tempDb.allDocs()).to.eventually.be.rejectedWith(wrongAuthError);
     const logs = await collectLogs();
-
-    console.log(logs);
 
     expect(utils.getSessionRequests(logs, false).length).to.equal(1);
     expect(utils.getDbRequest('undefined', logs, tempDbName, '/_all_docs', false).length).to.equal(2);

--- a/test/integration/credentials-auth.spec.js
+++ b/test/integration/credentials-auth.spec.js
@@ -87,7 +87,6 @@ describe(`integration with ${authType}`, async function () {
     tempDb = getDb(tempDbName, auth, authType);
 
     const collectLogs = await utils.getDockerContainerLogs();
-    await db.allDocs();
     await tempDb.allDocs();
 
     const logs = await collectLogs(100);

--- a/test/integration/credentials-auth.spec.js
+++ b/test/integration/credentials-auth.spec.js
@@ -92,6 +92,8 @@ describe(`integration with ${authType}`, async function () {
 
     const logs = await collectLogs(100);
 
+    console.log(logs);
+
     expect(utils.getDbRequest(auth.username, logs, tempDbName, '/_all_docs').length).to.equal(1);
     expect(utils.getSessionRequests(logs).length).to.equal(1);
     expect(utils.getCookieAuthRequests(auth.username, logs).length).to.equal(1);
@@ -109,6 +111,8 @@ describe(`integration with ${authType}`, async function () {
     await utils.createAdmin(auth.username, 'password change');
     await expect(tempDb.allDocs()).to.eventually.be.rejectedWith(wrongAuthError);
     const logs = await collectLogs();
+
+    console.log(logs);
 
     expect(utils.getSessionRequests(logs, false).length).to.equal(1);
     expect(utils.getDbRequest('undefined', logs, tempDbName, '/_all_docs', false).length).to.equal(2);

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   couchdb:
-    image: couchdb:3.3.3
+    image: "${COUCHDB_IMAGE}"
     environment:
       - "COUCHDB_USER=${COUCHDB_USER:-admin}"
       - "COUCHDB_PASSWORD=${COUCHDB_PASSWORD:-pass}"

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   couchdb:
-    image: "${COUCHDB_IMAGE}"
+    image: "${COUCHDB_IMAGE:-couchdb:3.3.3}"
     environment:
       - "COUCHDB_USER=${COUCHDB_USER:-admin}"
       - "COUCHDB_PASSWORD=${COUCHDB_PASSWORD:-pass}"

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -169,7 +169,10 @@ const setConfig = async (section, config, value, remove = false) => {
 };
 
 const setIterations = (iterations) => setConfig('chttpd_auth', 'iterations', iterations);
-const setAuthTimeout = (timeout) => setConfig('chttpd_auth', 'timeout', timeout);
+const setAuthTimeout = async (timeout) => {
+  await setConfig('chttpd_auth', 'timeout', timeout); // couch3
+  await setConfig('couch_httpd_auth', 'timeout', timeout); // couch2
+};
 
 const waitForCouchdb = async () => {
   // eslint-disable-next-line no-constant-condition

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -20,9 +20,9 @@ const killSpawnedProcess = (proc) => {
 };
 
 const waitForDockerContainerLogs = (...regex) => {
-  const params = 'logs --follow --tail=1 couchdb';
+  const params = 'compose logs --follow --tail=1 couchdb';
   const proc = spawn(
-    'docker-compose',
+    'docker',
     params.split(' '),
     {
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -64,9 +64,9 @@ const waitForDockerContainerLogs = (...regex) => {
 };
 
 const getDockerContainerLogs = (...regex) => {
-  const params = 'logs --follow --tail=1 couchdb';
+  const params = 'compose logs --follow --tail=1 couchdb';
   const proc = spawn(
-    'docker-compose',
+    'docker',
     params.split(' '),
     {
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -143,6 +143,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic YWRtaW46cGFzcw==',
           }),
           body: JSON.stringify({ name: 'admin', password: 'pass' }),
         }
@@ -175,6 +176,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic YWRtaW46cGFzcw==',
           }),
           body: JSON.stringify({ name: 'admin', password: 'pass' }),
         }
@@ -213,6 +215,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic YWRtaW46cGFzcw==',
           }),
           body: JSON.stringify({ name: 'admin', password: 'pass' }),
         }
@@ -261,6 +264,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic dXNyMTpwYXNz',
           }),
           body: JSON.stringify({ name: 'usr1', password: 'pass' }),
         }
@@ -276,6 +280,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic dXNyMjpwYXNz',
           }),
           body: JSON.stringify({ name: 'usr2', password: 'pass' }),
         }
@@ -365,6 +370,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic YWRtaW46cGFzcw==',
           }),
           body: JSON.stringify({ name: 'admin', password: 'pass' }),
         }
@@ -408,6 +414,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic YWRtaW46cGFzcw==',
           }),
           body: JSON.stringify({ name: 'admin', password: 'pass' }),
         }
@@ -461,6 +468,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic dXNyOnBhc3M=',
           }),
           body: JSON.stringify({ name: 'usr', password: 'pass' }),
         }
@@ -484,6 +492,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic dXNyOnBhc3M=',
           }),
           body: JSON.stringify({ name: 'usr', password: 'pass' }),
         }
@@ -525,6 +534,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic dXNyOnBhc3M=',
           }),
           body: JSON.stringify({ name: 'usr', password: 'pass' }),
         }
@@ -541,6 +551,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic dXNyOnBhc3M=',
           }),
           body: JSON.stringify({ name: 'usr', password: 'pass' }),
         }
@@ -569,6 +580,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic YWRtaW46cGFzcw==',
           }),
           body: JSON.stringify({ name: 'admin', password: 'pass' }),
         }
@@ -586,6 +598,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic YWRtaW46cGFzcw==',
           }),
           body: JSON.stringify({ name: 'admin', password: 'pass' }),
         }
@@ -634,6 +647,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic YWRtaW46cGFzcw==',
           }),
           body: JSON.stringify({ name: 'admin', password: 'pass' }),
         }
@@ -662,6 +676,7 @@ describe('Pouchdb Session authentication plugin', () => {
           headers: new Headers({
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Authorization': 'Basic YWRtaW46cGFzcw==',
           }),
           body: JSON.stringify({ name: 'admin', password: 'pass' }),
         }


### PR DESCRIPTION
In CouchDb v2, the POST _session request _must_ be loaded with both payload AND basic auth. 
Adds matrix to test CouchDb 2 and CouchDb 3. 
CouchDb 2 uses medic image because it incorporates security configs and reduces the overhead required in the tests. 